### PR TITLE
Validate cluster grouping length

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -104,6 +104,9 @@ validate_clusters <- function(clusters, barcode_count) {
   if (any(sapply(clusters, length) != barcode_count)) {
     return(err("cluster must have the same length as the number of barcodes"))
   }
+  if (any(sapply(clusters, nlevels) > 32768)) {
+    return(err("cluster cannot have more than 32768 groupings"))
+  }
 
   SUCCESS
 }

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -94,6 +94,12 @@ test_that("validate clusters", {
   expect_false(resp$success)
   expect_match(resp$msg, "same length as the number of barcodes")
 
+  # too many groupings
+  factors <- list("f1" = factor(seq(32769)))
+  resp <- validate_clusters(factors, length(factors[[1]]))
+  expect_false(resp$success)
+  expect_match(resp$msg, "cluster cannot have more than")
+
   # good
   factors <- list("f1" = factor(c("one", "two", "three")))
   resp <- validate_clusters(factors, 3)


### PR DESCRIPTION
This adds a validation check for each cluster that the number of groupings (factor levels) is within the supported limits of Loupe Browser. Currently, Loupe Browser supports the values [0, 32767] inclusive, which means that the max number of allowed groupings is 32768.

This should make debugging issues like #2 easier than the more cryptic error returned currently.