### PR TITLE
Esacape shell args to allow paths with spaces.

### DIFF
--- a/R/cmd.R
+++ b/R/cmd.R
@@ -29,8 +29,8 @@ louper_create_cloupe <- function(
   h5path <- normalizePath(path.expand(h5path))
   loupe_path <- suppressWarnings(normalizePath(path.expand(loupe_path)))
 
-  input_flag <- sprintf("--input=%s", h5path)
-  output_flag <- sprintf("--output=%s", loupe_path)
+  input_flag <- sprintf("--input=%s", shQuote(h5path))
+  output_flag <- sprintf("--output=%s", shQuote(loupe_path))
   args <- c("create", input_flag, output_flag)
 
   if (file.exists(loupe_path) && !force) {

--- a/tests/testthat/mock_louper
+++ b/tests/testthat/mock_louper
@@ -1,5 +1,59 @@
 #!/usr/bin/env bash
 
 echo "-----------RUNNING MOCK LOUPER EXECUTABLE--------------"
-echo Arguments passed to the script: "$@"
+
+# Default values
+force=false
+
+# Check if the correct number of arguments is provided
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    echo "Usage: $0 create --input=SOME_PATH --output=SOME_PATH [--force]"
+    exit 1
+fi
+
+# Check if the first argument is "create"
+if [ "$1" != "create" ]; then
+    echo "Error: First argument must be 'create'"
+    exit 1
+fi
+
+# shift args
+shift
+
+# Parse and validate the input and output options
+input=""
+output=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --input=*)
+            input="${1#*=}"
+            ;;
+        --output=*)
+            output="${1#*=}"
+            ;;
+        --force)
+            force=true
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Check if input and output paths are provided
+if [ -z "$input" ] || [ -z "$output" ]; then
+    echo "Error: Both --input and --output options must be provided"
+    exit 1
+fi
+
+# Additional processing with the arguments can be added here
+
+echo "Action: create"
+echo "Input path: $input"
+echo "Output path: $output"
+echo "Force: $force"
+
 echo "-------------------------------------------------------"

--- a/tests/testthat/mock_louper.bat
+++ b/tests/testthat/mock_louper.bat
@@ -1,5 +1,66 @@
 @echo off
 
 echo "-----------RUNNING MOCK LOUPER.BAT EXECUTABLE--------------"
-echo Arguments passed to the script: %*
+
+setlocal enabledelayedexpansion
+
+set "force=false"
+
+REM Check if the correct number of arguments is provided
+if "%~1" neq "create" (
+    echo Error: First argument must be 'create'
+    goto :eof
+)
+shift
+
+REM Parse and validate the input and output options
+set "input="
+set "output="
+
+:parse_args
+if "%~1" equ "" goto :check_paths
+
+if /i "%~1" equ "--input" (
+    set "input=%~2"
+    shift
+    shift
+    goto :parse_args
+)
+
+if /i "%~1" equ "--output" (
+    set "output=%~2"
+    shift
+    shift
+    goto :parse_args
+)
+
+if /i "%~1" equ "--force" (
+    set "force=true"
+    shift
+    goto :parse_args
+)
+
+echo Error: Unknown option '%1'
+goto :eof
+
+:check_paths
+REM Check if input and output paths are provided
+if not defined input (
+    echo Error: --input option must be provided
+    goto :eof
+)
+
+if not defined output (
+    echo Error: --output option must be provided
+    goto :eof
+)
+
+REM Additional processing with the arguments can be added here
+
+echo Action: create
+echo Input path: !input!
+echo Output path: !output!
+echo Force: !force!
+
+:end
 echo "-----------------------------------------------------------"

--- a/tests/testthat/test-lib.R
+++ b/tests/testthat/test-lib.R
@@ -1,4 +1,4 @@
-test_that("can run create_loupe_from_seurat", {
+create_default_seurat_obj <- function() {
   barcode_count <- 3
 
   count_mat <- create_count_mat(100, barcode_count, valid_barcodes = TRUE)
@@ -9,23 +9,38 @@ test_that("can run create_loupe_from_seurat", {
   obj[["proj1"]] <- proj
   obj[["cluster1"]] <- cluster
 
+  obj
+}
+
+test_that("can run create_loupe_from_seurat", {
   # create eula lock file to avoid interactive setup
   eula_create()
 
+  obj <- create_default_seurat_obj()
   x <- create_loupe_from_seurat(obj, executable_path = get_executable_path())
   expect(x, "create_loupe_from_seurat returns TRUE")
 })
 
+test_that("can run create_loupe with spaces in output_name", {
+  # create eula lock file to avoid interactive setup
+  eula_create()
+
+  obj <- create_default_seurat_obj()
+  x <- create_loupe_from_seurat(obj, executable_path = get_executable_path(), output_name = "name with spaces")
+  expect(x, "create_loupe_from_seurat returns TRUE")
+})
+
 test_that("can run create_loupe", {
+  # create eula lock file to avoid interactive setup
+  eula_create()
+
   barcode_count <- 5
   count_mat <- create_count_mat(100, barcode_count, valid_barcodes = TRUE)
   proj <- create_dense_mat(barcode_count, 2)
   clusters <- list("f1" = factor(c("a", "c", "b", "a", "b"), levels=c("a", "b", "c"), ordered=TRUE))
   projections <- list("p1" = proj)
 
-  # create eula lock file to avoid interactive setup
-  eula_create()
-
   x <- create_loupe(count_mat, clusters = clusters, projections = projections, executable_path = get_executable_path())
   expect(x, "create_loupe returns TRUE")
 })
+


### PR DESCRIPTION
This should hopefully fix the issue on windows where output paths with spaces are causing bad inputs to the executable.  It seems that using the `normalizePath` function on windows will convert relative paths to absolute paths, where on MacOS this isn't the case.  This is why the issue of spaces in paths only has been reported by windows users.