### PR TITLE
filter bad clusters with missing/empty levels

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -112,6 +112,16 @@ select_clusters <- function(obj, dedup=FALSE) {
     }
   }
 
+  # remove clusters that are missing factor levels or have a single empty level name
+  good_clusters <- sapply(clusters, function(f) {
+    if (length(levels(f)) == 0) {
+      return(FALSE)
+    }
+    max(as.numeric(lapply(levels(f), nchar))) > 0
+  })
+
+  clusters <- clusters[good_clusters]
+
   if (dedup) deduplicate_clusters(clusters) else clusters
 }
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -127,6 +127,15 @@ validate_clusters <- function(clusters, barcode_count) {
   if (any(sapply(clusters, nlevels) > 32768)) {
     return(err("cluster cannot have more than 32768 groupings"))
   }
+  if (any(sapply(clusters, nlevels) == 0)) {
+    return(err("cluster must have at least one grouping"))
+  }
+  for (clusterIdx in seq_along(clusters)) {
+    l <- levels(clusters[[clusterIdx]])
+    if (!all(sapply(l, nchar))) {
+      return(err("cluster group names cannot be the empty string"))
+    }
+  }
 
   SUCCESS
 }

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -141,6 +141,18 @@ test_that("validate clusters", {
   expect_false(resp$success)
   expect_match(resp$msg, "cluster cannot have more than")
 
+  # cluster with zero levels
+  factors <- list("f1" = factor(seq(32769), levels = c()))
+  resp <- validate_clusters(factors, length(factors[[1]]))
+  expect_false(resp$success)
+  expect_match(resp$msg, "cluster must have at least one grouping")
+
+  # cluster with one level, but it's empty
+  factors <- list("f1" = factor(seq(32769), levels = c("")))
+  resp <- validate_clusters(factors, length(factors[[1]]))
+  expect_false(resp$success)
+  expect_match(resp$msg, "cluster group names cannot be the empty string")
+
   # good
   factors <- list("f1" = factor(c("one", "two", "three")))
   resp <- validate_clusters(factors, 3)


### PR DESCRIPTION
Updates `select_clusters` to filter out factors with missing or empty factor levels.  Also, adds validation logic to catch this if someone is directly creating or passing clusters.

Prevents #37 from happening