### PR TITLE
Fix Version Comparison for Seurat Package

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -76,7 +76,7 @@ select_assay <- function(obj) {
 #'
 #' @export
 counts_matrix_from_assay <- function(assay) {
-  if (packageVersion("Seurat") >= 5) {
+  if (packageVersion("Seurat") >= package_version("5.0.0")) {
     return(assay$counts)
   } else {
     if (is(assay, 'Assay5')) {


### PR DESCRIPTION
To compare versions explicitly it is necessary to do it through another object of the type package_version Fixed #48 