### PR TITLE
fix: Cast projections to double PartII

### DIFF
--- a/R/hdf5.R
+++ b/R/hdf5.R
@@ -132,7 +132,8 @@ write_projections <- function(f, projections) {
 
     # cast to double as this is required during Loupe validation
     if (!is.double(projection)) {
-      projection <- as.double(projection)
+      vec <- as.double(projection)
+      projection <- matrix(vec, nrow = nrow(projection), ncol = ncol(projection))
     }
 
     is_umap <- grepl("umap", name, ignore.case = TRUE)

--- a/tests/testthat/test-hdf5.R
+++ b/tests/testthat/test-hdf5.R
@@ -76,7 +76,7 @@ test_that("will cast integer projections to float", {
   seurat_obj_version <- "1.2.3"
 
   # create a dense integer matrix
-  proj <- as.integer(create_dense_mat(barcode_count, 2) * 10)
+  proj <- matrix(as.integer(create_dense_mat(barcode_count, 2) * 10), nrow=barcode_count, ncol=2)
   projections <- list("p1" = proj)
 
   create_hdf5(count_mat, list(), projections, h5path, feature_ids, seurat_obj_version)
@@ -91,5 +91,8 @@ test_that("will cast integer projections to float", {
   expect_true(is.double(proj_data))
   expect_equal(proj, proj_data)
 
+  projs_group$close()
+  proj_group$close()
+  proj_dataset$close()
   f$close()
 })

--- a/tests/testthat/test-lib.R
+++ b/tests/testthat/test-lib.R
@@ -44,3 +44,18 @@ test_that("can run create_loupe", {
   expect(x, "create_loupe returns TRUE")
 })
 
+test_that("can run create_loupe with integer projection matrix", {
+  # create eula lock file to avoid interactive setup
+  eula_create()
+
+  barcode_count <- 5
+  count_mat <- create_count_mat(100, barcode_count, valid_barcodes = TRUE)
+  proj <- matrix(as.integer(create_dense_mat(barcode_count, 2) * 10), nrow=barcode_count, ncol=2)
+  clusters <- list("f1" = factor(c("a", "c", "b", "a", "b"), levels=c("a", "b", "c"), ordered=TRUE))
+  projections <- list("p1" = proj)
+
+  x <- create_loupe(count_mat, clusters = clusters, projections = projections, executable_path = get_executable_path())
+  expect(x, "create_loupe returns TRUE")
+})
+
+


### PR DESCRIPTION
Converting the matrix using as.double returns a vector and not a matrix.