### PR TITLE
feat: Add env var to overwrite where user data is stored

### DIFF
--- a/R/eula.R
+++ b/R/eula.R
@@ -71,7 +71,7 @@ eula_have_agreed <- function() {
 #' Path to directory that holds EULA agreement lock file
 #' @noRd
 eula_data_dir <- function() {
-  tools::R_user_dir("loupeR", "data")
+  get_user_data_dir()
 }
 
 #' Path to EULA agreement lock file

--- a/R/setup.R
+++ b/R/setup.R
@@ -148,7 +148,7 @@ verify_executable <- function(executable_path) {
 #'
 #' @noRd
 default_executable_path <- function() {
-  basedir <- tools::R_user_dir("loupeR", "data")
+  basedir <- get_user_data_dir()
   normalizePath(path.expand(file.path(basedir, executable_basename())), mustWork = FALSE)
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -1,3 +1,7 @@
+# Environment variable that allows overwriting the user data directory
+# If unset, defaults to: tools::R_user_dir("loupeR", "data")
+LOUPER_USER_DATA_DIR_ENV_VAR <- "LOUPER_USER_DATA_DIR" # nolint
+
 #' Log a message
 #'
 #' @param ... a variable number of character message parts
@@ -277,4 +281,19 @@ print_lines <- function(strs, prefix = "") {
   for (s in strs) {
     cat(sprintf("%s%s\n", prefix, s))
   }
+}
+
+#' Gets the path to the user directory on the machine where data is stored.
+#'
+#' @return A filesystem path to the user directory where things like the EULA can be stored.
+#'
+#' @noRd
+get_user_data_dir <- function() {
+  overwritten_data_dir <- Sys.getenv(LOUPER_USER_DATA_DIR_ENV_VAR)
+  overwritten_data_dir <- trimws(overwritten_data_dir)
+  if (overwritten_data_dir != "") {
+    return(overwritten_data_dir)
+  }
+
+  tools::R_user_dir("loupeR", "data")
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 Converting a Seurat object to a Loupe file is as simple as the following:
 
-```R
+```r
 # import the library
 library("loupeR")
 
@@ -36,7 +36,7 @@ create_loupe_from_seurat(seurat_obj)
 
 Use the function `create_loupe` if you need more control in the clusters and projections that included in the Loupe file.
 
-```R
+```r
 # import the library
 library("loupeR")
 
@@ -56,7 +56,7 @@ create_loupe(
 
 Additionally, use the utility function `read_feature_ids_from_tsv` to read the Ensemble ids from the 10x dataset. A Seurat object will only have imported the feature names or ids and attached these as rownames to the count matrix. In order for the Ensemble id links to work correctly within Loupe Browser, one must manually import them and include them.
 
-```R
+```r
 # import the library
 library("loupeR")
 
@@ -105,6 +105,10 @@ loupeR::setup()
 ### Automated installation and execution
 
 If you are interested in automating LoupeR installation and execution (and are blocked by interactive license acceptance), please write to [support@10xgenomics.com](mailto:support@10xgenomics.com) for further assistance.
+
+### Customizing the user data directory
+
+By default the louper executable, which is the binary that understands and creates Loupe files, will be stored in the system's `tools::R_user_dir` directory.  You can update this path by setting the environment variable `LOUPER_USER_DATA_DIR` to a directory of your choosing.
 
 ## Loupe Browser Compatibility
 
@@ -159,7 +163,7 @@ For more in depth documentation and support please head to our [support page](ht
 
 Additionally, we have provided utility functions to help gather useful information when contacting support or creating a Github issue.
 
-```R
+```r
 # import the library
 library("loupeR")
 


### PR DESCRIPTION
The environment variable 'LOUPER_USER_DATA_DIR', when set will determine where user data like the EULA or louper executable are stored.