### PR TITLE
feat: Allow filtering metadata columns

### DIFF
--- a/R/lib.R
+++ b/R/lib.R
@@ -7,6 +7,7 @@
 #' @param obj A Seurat Object
 #' @param output_dir optional directory where the Loupe file will be written
 #' @param output_name optional name of the Loupe file with the extensions not included.
+#' @param metadata_cols optional list that specifies which metadata columns to retain when selecting clusters
 #' @param dedup_clusters optional logical that will try to deduplicate all clusters that are numerically the same
 #' @param feature_ids optional character vector that specifies the feature ids of the count matrix.
 #'   Typically, these are the ensemble ids.
@@ -22,6 +23,7 @@ create_loupe_from_seurat <- function(
     obj,
     output_dir = NULL,
     output_name = NULL,
+    metadata_cols = NULL,
     dedup_clusters = FALSE,
     feature_ids = NULL,
     executable_path = NULL,
@@ -46,7 +48,7 @@ create_loupe_from_seurat <- function(
   assay <- named_assay[[1]]
   counts <- counts_matrix_from_assay(assay)
 
-  clusters <- select_clusters(obj, dedup = dedup_clusters)
+  clusters <- select_clusters(obj, dedup = dedup_clusters, metadata_cols = metadata_cols)
   projections <- select_projections(obj)
 
   log_msg("selected assay:", assay_name)

--- a/R/util.R
+++ b/R/util.R
@@ -95,18 +95,26 @@ counts_matrix_from_assay <- function(assay) {
 #'
 #' @param obj A Seurat Object
 #' @param dedup logical to dedupicate clusters.  Default TRUE.
+#' @param metadata_cols optional list that specifies which metadata columns to retain when selecting clusters
 #'
 #' @return A list of factors
 #'
 #' @importFrom Seurat Idents
 #'
 #' @export
-select_clusters <- function(obj, dedup = FALSE) {
+select_clusters <- function(
+    obj,
+    dedup = FALSE,
+    metadata_cols = NULL) {
   # Use the active.ident as a cluster
   clusters <- list(active_cluster = Seurat::Idents(obj))
 
   # Use all factors and character vectors from meta.data
   for (name in names(obj@meta.data)) {
+    if (!is.null(metadata_cols) && !(name %in% metadata_cols)) {
+      next
+    }
+
     data <- obj@meta.data[[name]]
 
     if (is.factor(data)) {

--- a/man/create_loupe_from_seurat.Rd
+++ b/man/create_loupe_from_seurat.Rd
@@ -8,6 +8,7 @@ create_loupe_from_seurat(
   obj,
   output_dir = NULL,
   output_name = NULL,
+  metadata_cols = NULL,
   dedup_clusters = FALSE,
   feature_ids = NULL,
   executable_path = NULL,
@@ -20,6 +21,8 @@ create_loupe_from_seurat(
 \item{output_dir}{optional directory where the Loupe file will be written}
 
 \item{output_name}{optional name of the Loupe file with the extensions not included.}
+
+\item{metadata_cols}{optional list that specifies which metadata columns to retain when selecting clusters}
 
 \item{dedup_clusters}{optional logical that will try to deduplicate all clusters that are numerically the same}
 

--- a/man/select_clusters.Rd
+++ b/man/select_clusters.Rd
@@ -4,12 +4,14 @@
 \alias{select_clusters}
 \title{Select clusters from the assay}
 \usage{
-select_clusters(obj, dedup = FALSE)
+select_clusters(obj, dedup = FALSE, metadata_cols = NULL)
 }
 \arguments{
 \item{obj}{A Seurat Object}
 
 \item{dedup}{logical to dedupicate clusters.  Default TRUE.}
+
+\item{metadata_cols}{optional list that specifies which metadata columns to retain when selecting clusters}
 }
 \value{
 A list of factors

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -65,6 +65,30 @@ test_that("select_clusters selects meta.data factors with deduplication", {
   expect_equal(clusters[[2]], cell_types)
 })
 
+test_that("select_clusters selects only some meta.data factors", {
+  rna <- create_count_mat(4, 4)
+  obj <- Seurat::CreateSeuratObject(rna, assay = "rna")
+
+  cell_types1 <- factor(c("a1", "a3", "a2", "a2"), levels = c("a1", "a2", "a3"))
+  obj@meta.data["cell_types1"] <- cell_types1
+
+  cell_types2 <- factor(c("b1", "b3", "b2", "b2"), levels = c("b1", "b2", "b3"))
+  obj@meta.data["cell_types2"] <- cell_types2
+
+  clusters <- select_clusters(obj, metadata_cols = c("cell_types1"))
+  expect_length(clusters, 2)
+  expect_equal(clusters[[2]], cell_types1)
+
+  clusters <- select_clusters(obj, metadata_cols = c("cell_types2"))
+  expect_length(clusters, 2)
+  expect_equal(clusters[[2]], cell_types2)
+
+  clusters <- select_clusters(obj, metadata_cols = c("cell_types1", "cell_types2"))
+  expect_length(clusters, 3)
+  expect_equal(clusters[[2]], cell_types1)
+  expect_equal(clusters[[3]], cell_types2)
+})
+
 test_that("select_projections select reductions", {
   rna <- create_count_mat(1000, 100)
   obj <- Seurat::CreateSeuratObject(rna, assay = "rna")


### PR DESCRIPTION
Added the parameter `metadata_cols` which takes a list of Seurat metadata names that will be retained as clusters in Loupe file.  Without supplying this list all viable columns are used as clusters.