### PR TITLE
fix: Error Message Handling Trailing Comma

### DIFF
--- a/R/err.R
+++ b/R/err.R
@@ -15,8 +15,8 @@ SUCCESS <- list(success = TRUE, msg = NULL) # nolint
 #' @noRd
 validation_err <- function(msg, name) {
   sprintf(
-    paste(
-      "\nIt looks like the formatting of your %s does not match the required formatting for LoupeR.",
+    paste0(
+      "\nIt looks like the formatting of your %s does not match the required formatting for LoupeR. ",
       "For further information, please see the documentation: 10xgen.com/louper\n\n%s"
     ),
     name,
@@ -28,9 +28,9 @@ validation_err <- function(msg, name) {
 #' @noRd
 general_err <- function(msg, name) {
   sprintf(
-    paste(
-      "\nIt looks like there was an issue with %s. For further information,",
-      "please see the documentation: 10xgen.com/louper\n\n%s",
+    paste0(
+      "\nIt looks like there was an issue with %s. ",
+      "For further information, please see the documentation: 10xgen.com/louper\n\n%s"
     ),
     name,
     msg

--- a/tests/testthat/test-lib.R
+++ b/tests/testthat/test-lib.R
@@ -18,6 +18,16 @@ setup({
   eula()
 })
 
+test_that("error helpers format messages correctly", {
+  general <- general_err("status code 1", "creating the loupe file")
+  validation <- validation_err("bad barcodes", "count matrix")
+
+  expect_match(general, "issue with creating the loupe file", fixed = TRUE)
+  expect_match(general, "status code 1", fixed = TRUE)
+  expect_match(validation, "formatting of your count matrix", fixed = TRUE)
+  expect_match(validation, "bad barcodes", fixed = TRUE)
+})
+
 test_that("can run create_loupe_from_seurat", {
   obj <- create_default_seurat_obj()
   x <- create_loupe_from_seurat(obj, executable_path = get_executable_path())


### PR DESCRIPTION
Note: AI-assisted most of the way.

Addresses an issue where the trailing comma is assumed to have a missing parameter in `general_err`. Switches everything to `paste0` + formatting without delimiters rather than using `paste` and the implicit ` ` delimiter. Also uses it in `validation_err` for consistency.

Related issue: https://github.com/10XGenomics/loupeR/issues/108 though this doesn't necessarily fix the error in loupeR, just the downstream error-logging problem.